### PR TITLE
Resolves #52 : [moto_sdar][moto_fdar] 'auto.bat' file MUST be flagged…

### DIFF
--- a/src/moto_lib/fs_disk/image_worker/content_injector.py
+++ b/src/moto_lib/fs_disk/image_worker/content_injector.py
@@ -42,6 +42,7 @@ class DiskImageContentInjector(DiskImageWorker):
             "BAS,A": self.processFileAsAsciiBasic,
             "BIN": self.processFileAsBinaryModule,
             "TXT": self.processFileAsTxt,
+            "AUTO.BAT": self.processFileAsTokenizedBasic,
         }
 
     ###########################################
@@ -263,10 +264,15 @@ class DiskImageContentInjector(DiskImageWorker):
                 fileData = sourceFile.read()
 
             # dispatch to a processor
+            fullFileName = f"{fileName}.{fileExtension}"
             process = (
-                self._processors[fileExtensionWithOption]
-                if fileExtensionWithOption in self._processors
-                else self._defaultProcessors
+                self._processors[fullFileName]
+                if fullFileName in self._processors
+                else (
+                    self._processors[fileExtensionWithOption]
+                    if fileExtensionWithOption in self._processors
+                    else self._defaultProcessors
+                )
             )
             process(listener, fileName, fileExtension, fileData)
 

--- a/tests/behavior/test_sdar_create.py
+++ b/tests/behavior/test_sdar_create.py
@@ -55,6 +55,8 @@ FILE_LONG_NAME = "too_long_name.foo"
 FILE_LONG_EXTENSION = "too_long.extension"
 FILE_NOT_FOUND = "whatever.foo"
 
+FILE_AUTO = "auto.bat"
+
 COMMON_FILESET = [
     FILE_A,
     FILE_B,
@@ -600,3 +602,94 @@ TOTAL
             assert usage.reserved == 3
             assert usage.free == 157
             assert len(fs.listFiles()) == 0
+
+
+def test_that_auto_bat_is_stored_as_tokenized_basic():
+    sourceFileSet = [FILE_AUTO]
+    tmp_dir = initializeTmpWorkspace(
+        [os.path.join(source_dir, f) for f in sourceFileSet]
+    )
+    createdImageFile = os.path.join(tmp_dir, FILE_IMAGE)
+    baseArgs = ["prog", "--create", "--verbose", createdImageFile]
+    sourceArgs = sourceFileSet
+    with patch.object(
+        sys, "argv", baseArgs + [os.path.join(tmp_dir, f) for f in sourceArgs]
+    ):
+        with redirect_stdout(io.StringIO()) as out:
+            returnCode = DiskArchiveCli().run()
+        assert returnCode == 0
+        assert (
+            out.getvalue()
+            == f"""Side 0
+  AUTO.BAT  BASIC   TOKEN   ......      11 Bytes      1 block 
+1 file, 1 block written (0.6%)
+---
+Side 1
+empty, 0 blocks written (0.0%)
+---
+Side 2
+empty, 0 blocks written (0.0%)
+---
+Side 3
+empty, 0 blocks written (0.0%)
+---
+TOTAL
+1 file, 1 block written
+"""
+        )
+
+        # Verify archive file
+        assert os.path.exists(createdImageFile)
+        # -- load the binary file as DiskImage
+        with open(createdImageFile, mode="rb") as infile:
+            actualImageData = infile.read()
+        actualImage = DiskImage(
+            actualImageData, typeOfDiskImage=TypeOfDiskImage.SDDRIVE_FLOPPY_IMAGE
+        )
+        # -- verify side 0
+        fs = FileSystemController(actualImage.sides[0])
+        usage = fs.computeUsage()
+        assert usage.used == 1
+        assert usage.reserved == 3
+        assert usage.free == 156
+        # -- -- get catalog and verify
+        catalog = fs.listFiles()
+        assert len(catalog) == 1
+        assert [f.toDict() for f in catalog] == [
+            {
+                "extension": "BAT",
+                "name": "AUTO    ",
+                "sizeInBlocks": 1,
+                "sizeInBytes": 11,
+                "status": "ALIVE",
+                "typeOfData": "TOKEN",
+                "typeOfFile": "BASIC",
+            },
+        ]
+        assert [fs.readFile(f) for f in catalog] == [
+            d
+            for d in [
+                "aaaaaaaaaa\n".encode(encoding="ascii"),
+            ]
+        ]
+        # -- verify side 1
+        fs = FileSystemController(actualImage.sides[1])
+        usage = fs.computeUsage()
+        assert usage.used == 0
+        assert usage.reserved == 3
+        assert usage.free == 157
+        assert len(fs.listFiles()) == 0
+        # -- verify side 2
+        fs = FileSystemController(actualImage.sides[2])
+        usage = fs.computeUsage()
+        assert usage.used == 0
+        assert usage.reserved == 3
+        assert usage.free == 157
+        assert len(fs.listFiles()) == 0
+        # -- verify side 3
+        fs = FileSystemController(actualImage.sides[3])
+        usage = fs.computeUsage()
+        assert usage.used == 0
+        assert usage.reserved == 3
+        assert usage.free == 157
+        assert len(fs.listFiles()) == 0

--- a/tests/data/create-disk-image/auto.bat
+++ b/tests/data/create-disk-image/auto.bat
@@ -1,0 +1,1 @@
+aaaaaaaaaa


### PR DESCRIPTION
… as tokenized basic file when creating/adding to a disk image archive